### PR TITLE
Add support for Conga3090 keeping Conga3490

### DIFF
--- a/lib/Valetudo.js
+++ b/lib/Valetudo.js
@@ -13,6 +13,7 @@ const RoborockGen3 = require("./devices/RoborockGen3");
 const RoborockS6 = require("./devices/RoborockS6");
 const Dreame = require("./devices/Dreame");
 const CecotecConga3490 = require("./devices/CecotecConga3490");
+const CecotecConga3090 = require("./devices/CecotecConga3090");
 
 class Valetudo {
     constructor() {
@@ -135,7 +136,8 @@ const MODEL_TO_IMPLEMENTATION = {
     "roborock.vacuum.a08": RoborockGen3,
     "roborock.vacuum.p5": RoborockGen3,
     "dreame.vacuum.mc1808": Dreame,
-    "cecotec.conga.3490": CecotecConga3490
+    "cecotec.conga.3490": CecotecConga3490,
+    "cecotec.conga.3090": CecotecConga3090
 };
 
 module.exports = Valetudo;

--- a/lib/devices/CecotecConga3090.js
+++ b/lib/devices/CecotecConga3090.js
@@ -56,8 +56,6 @@ const OPCODES = {
     "DEVICE_MAP_ID_SET_AREA_CLEAN_INFO_RSP": 0x1102,
     "DEVICE_MAP_ID_SET_NAVIGATION_REQ": 0x1103,
     "DEVICE_MAP_ID_SET_NAVIGATION_RSP": 0x1104,
-    "DEVICE_MAP_ID_GET_CONSUMABLES_PARAM_REQ": 0x1113,
-    "DEVICE_MAP_ID_GET_CONSUMABLES_PARAM_RSP": 0x1114,
     "DEVICE_MAP_ID_SET_SAVE_WAITING_MAP_INFO_REQ": 0x111B,
     "DEVICE_MAP_ID_SET_SAVE_WAITING_MAP_INFO_RSP": 0x111C,
     "DEVICE_GET_ALL_GLOBAL_MAP_INFO_REQ": 0x111f,
@@ -100,7 +98,6 @@ const COMMANDS = {
     SET_ORDER_LIST: ["DEVICE_ORDERLIST_SETTING_REQ", "DEVICE_ORDERLIST_SETTING_RSP"],
     DEL_ORDER_LIST: ["DEVICE_ORDERLIST_DELETE_REQ", "DEVICE_ORDERLIST_DELETE_RSP"],
     SAVE_WAITING_MAP_INFO: ["DEVICE_MAP_ID_SET_SAVE_WAITING_MAP_INFO_REQ", "DEVICE_MAP_ID_SET_SAVE_WAITING_MAP_INFO_RSP"],
-    GET_CONSUMABLES_PARAM: ["DEVICE_MAP_ID_GET_CONSUMABLES_PARAM_REQ", "DEVICE_MAP_ID_GET_CONSUMABLES_PARAM_RSP"],
 };
 
 /**
@@ -137,7 +134,7 @@ function toStream(buffer) {
  * @param {keyof Buffer} method
  */
 function readFn(size, method) {
-    return function read(stream) {
+    return (stream) => {
         const buffer = stream.read(size);
 
         assert(buffer, `read(${size}): empty value from stream`);
@@ -701,12 +698,7 @@ class Client extends EventEmitter {
         while (this.buffer.length > size) {
             const packet = Packet.fromBuffer(this.buffer);
 
-            try {
-                this.handlePacket(packet);
-            } catch (e) {
-                Logger.error(`Unable to handle packet '${packet.opname}': `, e);
-            }
-
+            this.handlePacket(packet);
             this.buffer = this.buffer.slice(size);
 
             if (this.buffer.length < 4) {
@@ -793,8 +785,6 @@ const FAN_SPEEDS = {
     [FAN_SPEED_STATE_VALUE.HIGH]: 3,
 };
 
-const UNKNOWN = "unknown";
-
 const FAN_SPEEDS_REVERSED = flip(FAN_SPEEDS);
 
 class DeviceStatus {
@@ -860,7 +850,7 @@ class DeviceStatus {
             return STATUS_STATE_VALUE.IDLE;
         }
 
-        return UNKNOWN;
+        return "unknown";
     }
 
     getStatusStateFlag() {
@@ -872,7 +862,7 @@ class DeviceStatus {
             return STATUS_STATE_FLAG.SPOT;
         }
 
-        return UNKNOWN;
+        return "unknown";
     }
 
     getStatusState() {
@@ -1064,28 +1054,7 @@ const MANUAL_MODE_COMMANDS = {
     INIT: 10
 };
 
-const MAIN_BRUSH_LIFE_TIME = 320;
-const SIDE_BRUSH_LIFE_TIME = 220;
-const FILTER_LIFE_TIME = 160;
-
-function waitFor(fn) {
-    return new Promise(resolve => {
-        let timer = setInterval(check, 50);
-
-        function check() {
-            const ret = fn();
-
-            if (ret) {
-                clearInterval(timer);
-                resolve();
-            }
-        }
-
-        check();
-    });
-}
-
-class CecotecConga3490 {
+class CecotecConga3090 {
     constructor(options) {
         this.device = null;
         this.deviceStatus = new DeviceStatus();
@@ -1108,7 +1077,7 @@ class CecotecConga3490 {
             DEVICE_MAP_ID_PUSH_MAP_INFO: this.handleMapUpdate.bind(this),
             DEVICE_MAP_ID_PUSH_POSITION_INFO: this.handleUpdateRobotPosition.bind(this),
             DEVICE_MAP_ID_PUSH_CHARGE_POSITION_INFO: this.handleUpdateChargePosition.bind(this),
-            DEVICE_WORKSTATUS_REPORT_REQ: this.handleWorkstatusReport.bind(this),
+            DEVICE_WORKSTATUS_REPORT_RSP: this.handleUnk1.bind(this),
         };
         this.cmdServer = new Server(4010, this.handlers);
         this.mapServer = new Server(4030, this.handlers);
@@ -1277,34 +1246,6 @@ class CecotecConga3490 {
         return [];
     }
 
-    async getConsumableStatus() {
-        await waitFor(() => this.deviceStatus.getStatusStateValue() !== UNKNOWN);
-
-        const { packet: { data } } = await this.cmdServer.sendCommand("GET_CONSUMABLES_PARAM");
-
-        return {
-            mainBrushLeftTime: Math.max(MAIN_BRUSH_LIFE_TIME - data.mainBrushTime, 0),
-            sideBrushLeftTime: Math.max(SIDE_BRUSH_LIFE_TIME - data.sideBrushTime, 0),
-            filterLeftTime: Math.max(FILTER_LIFE_TIME - data.filterTime, 0),
-            // No sensor metrics on Conga
-            sensorLeftTime: Math.max(MAIN_BRUSH_LIFE_TIME - data.mainBrushTime, 0),
-        };
-    }
-
-    async getCleanSummary() {
-        return {
-            cleanTime: this.deviceStatus.cleanTime * 60,
-            cleanArea: this.deviceStatus.cleanSize * 100,
-            cleanCount: 1,
-            lastRuns: [] // array containing up to 20 runs from the past
-        };
-    }
-
-    getZoneCleaningStatus() {
-        // NOT IMPLEMENTED
-        return [];
-    }
-
     async handlePing(message) {
         await message.buildResponse("CLIENT_HEARTBEAT_RSP").send();
         await this.cmdServer.sendCommand("DEVICE_CHECK");
@@ -1418,9 +1359,9 @@ class CecotecConga3490 {
         this.events.emitMapUpdated();
     }
 
-    async handleWorkstatusReport(message) {
+    async handleUnk1(message) {
         await message.buildResponse("DEVICE_WORKSTATUS_REPORT_RSP", { result: 0 }).send();
     }
 }
 
-module.exports = CecotecConga3490;
+module.exports = CecotecConga3090;


### PR DESCRIPTION
Hi Flock-zz

I've added a new instance for Conga3090 in /lib/Valetudo.js allowing us to have the same Valetudo for both 3090 and 3490.
I've restored the orginial /lib/devices/CecoctecConga3490.js created by Adrigzr
I've created /lib/devices/CecotecConga3090.js with new constructor and export for the CecotecConga3090, with the m odifications made from CecotecConga3490.js by Flock-zz

Please review them

Regards